### PR TITLE
Improve layout responsiveness and button styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,14 @@ html, body {
     background: black;
 }
 
+button, .btn {
+    background-color: rgb(238, 0, 0);
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+    color: white;
+}
+
 #content {
     width: 100%;
     height: 100%;
@@ -13,8 +21,9 @@ html, body {
     width: 500px;
     height: 300px;
     position: absolute;
-    top: 20px;
+    top: 50%;
     right: 20px;
+    transform: translateY(-50%);
     z-index: 1000;
     box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
 }
@@ -44,10 +53,14 @@ html, body {
     top: 340px;
     right: 20px;
     z-index: 1000;
+    background-color: rgb(238, 0, 0);
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
 }
 
 #guessButton:hover {
-    background: #FF6666;
+    background: rgb(238, 0, 0);
 }
 
 #image {
@@ -55,7 +68,7 @@ html, body {
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     object-fit: cover;
     z-index: 1;
 }
@@ -132,4 +145,19 @@ select {
 /* Change cursor when over entire map */
 .leaflet-container {
     cursor: default !important;
+}
+
+@media (max-width: 767px) {
+    #image {
+        height: 50vh;
+    }
+    #miniMap {
+        width: 100%;
+        height: 50vh;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        top: auto;
+        transform: none;
+    }
 }


### PR DESCRIPTION
## Summary
- center minimap vertically on large screens and move it to the bottom on phones
- allow the main photo to fill the entire page or the top half on phones
- restyle buttons with a flat red look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ed74ddabc8323b9d5b0c06e13aafc