### PR TITLE
Fix broken CSS welcome screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-html, body {Add commentMore actions
+html, body {
     width: 100%;
     height: 100%;
     background: black;
@@ -194,7 +194,7 @@ select {
         top: auto;
         transform: none;
     }
-    #miniMap {Add commentMore actions
+    #miniMap {
         width: 100%;
         height: 50vh;
     }


### PR DESCRIPTION
## Summary
- remove stray text from `style.css` that corrupted the stylesheet

This resolves the issue where the welcome screen only displayed a black background.

## Testing
- `npm start` *(fails: live-server not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eeac500c883238ae09b3f5610e562