### PR TITLE
Enable zooming on location images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -112,6 +112,13 @@ button, .btn {
     height: 100vh;
     object-fit: cover;
     z-index: 1;
+    cursor: grab;
+    user-select: none;
+    touch-action: none;
+}
+
+#image.grabbing {
+    cursor: grabbing;
 }
 
 #scoreBoard {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>
         <script type='text/javascript' src='js/app.js'></script>
+        <script type='text/javascript' src='js/image_zoom.js'></script>
     </head>
     <body>
         <div id="welcomeScreen">

--- a/js/image_zoom.js
+++ b/js/image_zoom.js
@@ -1,0 +1,49 @@
+$(function(){
+    var img = $('#image');
+    var scale = 1;
+    var minScale = 1;
+    var maxScale = 5;
+    var transX = 0;
+    var transY = 0;
+    var dragging = false;
+    var startX = 0;
+    var startY = 0;
+
+    function updateTransform(){
+        img.css('transform','translate('+transX+'px,'+transY+'px) scale('+scale+')');
+    }
+
+    img.on('wheel', function(e){
+        e.preventDefault();
+        var delta = e.originalEvent.deltaY;
+        if(delta < 0){
+            scale *= 1.1;
+        } else {
+            scale /= 1.1;
+        }
+        scale = Math.min(Math.max(scale, minScale), maxScale);
+        updateTransform();
+    });
+
+    img.on('mousedown touchstart', function(e){
+        var ev = e.type === 'touchstart' ? e.touches[0] : e;
+        dragging = true;
+        img.addClass('grabbing');
+        startX = ev.clientX - transX;
+        startY = ev.clientY - transY;
+    });
+
+    $(document).on('mousemove touchmove', function(e){
+        if(!dragging) return;
+        if(e.type === 'touchmove') e.preventDefault();
+        var ev = e.type === 'touchmove' ? e.touches[0] : e;
+        transX = ev.clientX - startX;
+        transY = ev.clientY - startY;
+        updateTransform();
+    });
+
+    $(document).on('mouseup touchend touchcancel', function(){
+        dragging = false;
+        img.removeClass('grabbing');
+    });
+});


### PR DESCRIPTION
## Summary
- add `image_zoom.js` to handle mouse and touch zooming/panning
- style the main image for interactive cursor changes
- include the new script on the main page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684eee7129408323a98544728b718e3d