### PR TITLE
Fix image zoom initialization and mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,7 +198,7 @@ select {
 
 @media (max-width: 767px) {
     #image {
-        height: 50vh;
+        height: 55vh;
     }
     #miniMapWrapper {
         width: 100%;
@@ -207,9 +207,10 @@ select {
         left: 0;
         top: auto;
         transform: none;
+        height: 50vh;
     }
     #miniMap {
         width: 100%;
-        height: 50vh;
+        height: calc(100% - 50px);
     }
 }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>
         <script type='text/javascript' src='js/app.js'></script>
-        <script type='text/javascript' src='js/image_zoom.js'></script>
+        <script type='text/javascript' src='js/image_zoom.js' defer></script>
     </head>
     <body>
         <div id="welcomeScreen">


### PR DESCRIPTION
## Summary
- ensure image zoom script initializes after DOM load
- adjust map and photo ratios on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684efea99ecc832396acdf6519b5f269