### PR TITLE
Fix image zoom boundaries

### DIFF
--- a/js/image_zoom.js
+++ b/js/image_zoom.js
@@ -16,12 +16,11 @@
         const containerWidth = container.clientWidth;
         const containerHeight = container.clientHeight;
 
-        const imageWidth = img.naturalWidth * scale;
-        const imageHeight = img.naturalHeight * scale;
 
-        const minX = Math.min(0, containerWidth - imageWidth);
+
+        const minX = containerWidth * (1 - scale) / scale;
         const maxX = 0;
-        const minY = Math.min(0, containerHeight - imageHeight);
+        const minY = containerHeight * (1 - scale) / scale;
         const maxY = 0;
 
         tx = Math.min(Math.max(tx, minX), maxX);


### PR DESCRIPTION
## Summary
- prevent zooming past the bottom and right edges by clamping translation using the image's scale

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f074e3d98832381e9d7bf2aae607d