### PR TITLE
Fix mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -197,20 +197,31 @@ select {
 }
 
 @media (max-width: 767px) {
+    /* show the image only in the top half of the viewport */
     #image {
-        height: 55vh;
+        height: 50vh;
     }
+
+    /* place the map at the bottom and make it smaller */
     #miniMapWrapper {
+        position: fixed;
         width: 100%;
         bottom: 0;
         right: 0;
         left: 0;
         top: auto;
         transform: none;
-        height: 50vh;
+        height: 40vh;
     }
+
     #miniMap {
         width: 100%;
-        height: calc(100% - 50px);
+        height: calc(100% - 40px);
+    }
+
+    /* smaller guess button on small screens */
+    #guessButton {
+        font-size: 18px;
+        padding: 8px 0;
     }
 }


### PR DESCRIPTION
## Summary
- update media queries for mobile layout
- reduce image height to half the viewport on phones
- shrink map and guess button and fix them to the bottom of the screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f0c25a1dc832393ab4124cf17be04