### PR TITLE
Improve mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,10 @@ html, body {
 }
 
 #welcomeScreen button {
-    margin-top: 20px;
+    position: absolute;
+    bottom: 10px;
+    font-size: 24px;
+    padding: 15px 30px;
 }
 
 @keyframes fadeIn {
@@ -134,6 +137,10 @@ button, .btn {
     z-index: 1000;
 }
 
+#scoreBoardMobile {
+    display: none;
+}
+
 select {
     width: 200px;
 }
@@ -217,6 +224,34 @@ select {
     #miniMap {
         width: 100%;
         height: calc(100% - 40px);
+    }
+
+    #roundEnd {
+        width: 90vw;
+        left: 5vw;
+        margin-left: 0;
+    }
+
+    #scoreBoard {
+        display: none;
+    }
+
+    #scoreBoardMobile {
+        display: flex;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: white;
+        padding: 5px;
+        justify-content: space-around;
+        box-shadow: 0 0 10px rgba(0,0,0,0.5);
+        font-size: 12px;
+        z-index: 1000;
+    }
+
+    #scoreBoardMobile span {
+        margin: 0 2px;
     }
 
     /* smaller guess button on small screens */

--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
                 <span class='totalScore'>Total Score: <b>0</b></span><br />
                 <span><a href="https://github.com/blinry/wikidata-guessr">View project on GitHub</a></span>
             </div>
+            <div id='scoreBoardMobile'>
+                <span class='round'>R: <b>1/5</b></span>
+                <span class='roundScore'>L: <b>0</b></span>
+                <span class='totalScore'>T: <b>0</b></span>
+            </div>
             <div id='miniMapWrapper'>
                 <div id='miniMap'></div>
                 <div id='guessButton' class="btn btn-large btn-danger">Make Your Guess</div>

--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,10 @@ function startGame() {
             $('.roundScore').html('Last Round Score: <b>'+roundScore+'</b>');
             $('.totalScore').html('Total Score: <b>'+totalScore+'</b>');
 
+            $('#scoreBoardMobile .round').html('R: <b>'+round+'/5</b>');
+            $('#scoreBoardMobile .roundScore').html('L: <b>'+roundScore+'</b>');
+            $('#scoreBoardMobile .totalScore').html('T: <b>'+totalScore+'</b>');
+
             var img = document.getElementById('image');
             img.src = "";
 
@@ -191,7 +195,7 @@ function startGame() {
         roundScore = points;
         totalScore = totalScore + points;
 
-        $('#miniMap, #pano, #guessButton, #scoreBoard').hide();
+        $('#miniMap, #pano, #guessButton, #scoreBoard, #scoreBoardMobile').hide();
         $('#endGame').html('<h1>Congrats!</h1><h2>Your final score was:</h2><h1>'+totalScore+'!</h1><br/><button class="btn btn-large btn-success playAgain" type="button">Play Again?</button>');
         $('#endGame').fadeIn(500);
 


### PR DESCRIPTION
## Summary
- keep start button visible by moving it up and enlarging it
- add a mobile scoreboard bar
- hide old scoreboard on small screens
- ensure result popup fits on phones

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f81b9308323aca42488f519be8e