### PR TITLE
Adjust scoreboard on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,16 +15,20 @@ html, body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    padding-bottom: 40px;              /* keep space below button */
+    box-sizing: border-box;
     z-index: 2000;
     animation: fadeIn 1s, gradientPulse 6s ease-in-out infinite;
 }
 
 #welcomeScreen img {
     max-width: 80%;
+    max-height: calc(100vh - 160px);   /* leave room for the button */
 }
 
 #welcomeScreen button {
     margin-top: 20px;
+    margin-bottom: 20px;               /* padding under the button */
 }
 
 @keyframes fadeIn {

--- a/css/style.css
+++ b/css/style.css
@@ -243,4 +243,25 @@ select {
         font-size: 18px;
         padding: 8px 0;
     }
+
+    /* make the round result and final result boxes fit the viewport */
+    #roundEnd,
+    #endGame {
+        width: 90%;
+        left: 50%;
+        right: auto;
+        margin: 20px 0 0 0;
+        transform: translateX(-50%);
+    }
+
+    #endGame {
+        top: 50%;
+        margin-top: 0;
+        transform: translate(-50%, -50%);
+    }
+
+    #roundEnd #roundMap {
+        width: 100%;
+        height: 200px;
+    }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -134,6 +134,25 @@ button, .btn {
     z-index: 1000;
 }
 
+@media (max-width: 767px) {
+    #scoreBoard {
+        position: fixed;
+        top: 0;
+        left: 50%;
+        bottom: auto;
+        right: auto;
+        transform: translateX(-50%);
+        width: 160px;
+        height: auto;
+        padding: 5px;
+        text-align: center;
+    }
+    #scoreBoard .roundScore,
+    #scoreBoard a {
+        display: none;
+    }
+}
+
 select {
     width: 200px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ html, body {
     top: 0;
     left: 0;
     width: 100vw;
-    height: 100vh;
+    height: 100dvh;                      /* ensure full viewport height on mobile */
     background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%);
     display: flex;
     flex-direction: column;
@@ -23,12 +23,14 @@ html, body {
 
 #welcomeScreen img {
     max-width: 80%;
-    max-height: calc(100vh - 160px);   /* leave room for the button */
+    max-height: calc(100dvh - 200px);  /* keep image from hiding the button */
 }
 
 #welcomeScreen button {
     margin-top: 20px;
-    margin-bottom: 20px;               /* padding under the button */
+    margin-bottom: 40px;               /* padding under the button */
+    font-size: 24px;                   /* bigger button text */
+    padding: 12px 32px;
 }
 
 @keyframes fadeIn {
@@ -146,13 +148,19 @@ button, .btn {
         bottom: auto;
         right: auto;
         transform: translateX(-50%);
-        width: 160px;
+        width: auto;
         height: auto;
-        padding: 5px;
-        text-align: center;
+        padding: 5px 10px;
+        display: flex;
+        gap: 10px;
+        white-space: nowrap;
+        align-items: center;
     }
     #scoreBoard .roundScore,
     #scoreBoard a {
+        display: none;
+    }
+    #scoreBoard br {
         display: none;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -151,7 +151,8 @@ button, .btn {
         width: auto;
         height: auto;
         padding: 5px 10px;
-        display: flex;
+        display: inline-flex; /* size to content so box remains narrow */
+        flex-wrap: nowrap;
         gap: 10px;
         white-space: nowrap;
         align-items: center;

--- a/js/app.js
+++ b/js/app.js
@@ -48,6 +48,7 @@ function startGame() {
     // End of round continue button click
     $('#roundEnd').on('click', '.closeBtn', function () {
         $('#roundEnd').fadeOut(500);
+        $('#scoreBoard').show();
 
         if (round < 5){
 
@@ -159,6 +160,7 @@ function startGame() {
         if(typeof distance === 'undefined' || ranOut == true){
             $('#roundEnd').html('<p>Dang nabbit! You took too long!.<br/> You didn\'t score any points this round!<br/><br/><button class="btn btn-primary closeBtn" type="button">Continue</button></p></p>');
             $('#roundEnd').fadeIn();
+            $('#scoreBoard').hide();
 
             // Stop Counter
             clearInterval(counter);
@@ -179,6 +181,7 @@ function startGame() {
         } else {
             $('#roundEnd').html('<p>Your guess was<br/><strong><h1>'+distance+'</strong>km</h1> away from the actual location,<br/><h2>'+window.locName+'</h2><div id="roundMap"></div><br/> You have scored<br/><h1>'+roundScore+' points</h1> this round!<br/><br/><button class="btn btn-primary closeBtn" type="button">Continue</button></p></p>');
             $('#roundEnd').fadeIn();
+            $('#scoreBoard').hide();
         };
 
         // Reset Params


### PR DESCRIPTION
## Summary
- adjust mobile CSS for `#scoreBoard`
  - anchor it to the top of the screen
  - make it narrower
  - hide the last-round score and github link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f226654448323bf0a81c0755e70fe