### PR TITLE
Add explainer screen between rounds

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -189,6 +189,19 @@ select {
     box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
 }
 
+#explainerBox {
+    position: absolute;
+    left: 50%;
+    width: 400px;
+    margin: 40px 0 0 -200px;
+    padding: 20px;
+    background: white;
+    text-align: center;
+    display: none;
+    z-index: 1005;
+    box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
+}
+
 #roundEnd #roundMap {
     width: 400px;
     height: 300px;
@@ -259,6 +272,7 @@ select {
 
     /* make the round result and final result boxes fit the viewport */
     #roundEnd,
+    #explainerBox,
     #endGame {
         width: 90%;
         left: 50%;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
         </div>
         <div id='content'>
             <div id="roundEnd"></div>
+            <div id="explainerBox">
+                <p id="explainerText"></p>
+                <button id="nextRoundButton" class="btn btn-primary">Next Round</button>
+            </div>
             <div id="endGame"></div>
             <div id='scoreBoard'>
                 <span class='round'>Current Round: <b>1/5</b></span><br/>

--- a/js/app.js
+++ b/js/app.js
@@ -47,36 +47,18 @@ function startGame() {
 
     // End of round continue button click
     $('#roundEnd').on('click', '.closeBtn', function () {
-        $('#roundEnd').fadeOut(500);
+        $('#roundEnd').fadeOut(500, function(){
+            $('#explainerText').text(window.locExplainer);
+            $('#explainerBox').fadeIn(500);
+            document.getElementById('explainerBox').scrollIntoView({behavior: 'smooth'});
+        });
         $('#scoreBoard').show();
+    });
 
-        if (round < 5){
-
-            round++
-            if(ranOut==true){
-                roundScore = 0;
-            } else {
-                roundScore = points;
-                totalScore = totalScore + points;
-            }
-
-            $('.round').html('Current Round: <b>'+round+'/5</b>');
-            $('.roundScore').html('Last Round Score: <b>'+roundScore+'</b>');
-            $('.totalScore').html('Total Score: <b>'+totalScore+'</b>');
-
-            var img = document.getElementById('image');
-            img.src = "";
-
-            // Reload maps to refresh coords
-            svinitialize();
-            guess2.setLatLng({lat: -999, lng: -999});
-            mymap.setView([30, 10], 1);
-
-            // Reset Timer
-            resetTimer();
-        } else if (round >= 5){
-            endGame();
-        };
+    // Explainer "next round" button
+    $('#explainerBox').on('click', '#nextRoundButton', function () {
+        $('#explainerBox').fadeOut(500);
+        nextRound();
     });
 
     // End of game 'play again' button click
@@ -189,7 +171,7 @@ function startGame() {
 
     };
 
-    function endGame(){
+function endGame(){
 
         roundScore = points;
         totalScore = totalScore + points;
@@ -219,12 +201,43 @@ function startGame() {
                     img.src = place.image;
                     window.actualLatLng = {lat: place.lat, lon: place.lon};
                     window.locName = place.label;
+                    window.locExplainer = place.explainer || '';
                 });
             })
             .catch(function(err) {
                 console.warn('Fetch Error :-S', err);
             });
     };
+
+    function nextRound(){
+        if (round < 5){
+
+            round++
+            if(ranOut==true){
+                roundScore = 0;
+            } else {
+                roundScore = points;
+                totalScore = totalScore + points;
+            }
+
+            $('.round').html('Current Round: <b>'+round+'/5</b>');
+            $('.roundScore').html('Last Round Score: <b>'+roundScore+'</b>');
+            $('.totalScore').html('Total Score: <b>'+totalScore+'</b>');
+
+            var img = document.getElementById('image');
+            img.src = "";
+
+            // Reload maps to refresh coords
+            svinitialize();
+            guess2.setLatLng({lat: -999, lng: -999});
+            mymap.setView([30, 10], 1);
+
+            // Reset Timer
+            resetTimer();
+        } else {
+            endGame();
+        }
+    }
 }
 
 $(document).ready(function(){


### PR DESCRIPTION
## Summary
- add an explainer overlay containing info from `locations.json`
- include a "Next Round" button inside the overlay
- modify flow so the existing Continue button scrolls to this new overlay
- support the `explainer` field in fetched location data
- style the new overlay and update responsive rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684feb10ea048323925461dc74a3cfc7