### PR TITLE
Add explainer step

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -45,7 +45,7 @@ function startGame() {
         rminitialize();
     });
 
-    // End of round continue button click
+    // End of round "next round" button click
     $('#roundEnd').on('click', '.closeBtn', function () {
         $('#roundEnd').fadeOut(500);
         $('#scoreBoard').show();
@@ -77,6 +77,13 @@ function startGame() {
         } else if (round >= 5){
             endGame();
         };
+    });
+
+    // After showing round results, the first Continue button displays the
+    // explainer text instead of immediately starting the next round.
+    $('#roundEnd').on('click', '.continueBtn', function () {
+        var explainerImg = window.explainerImage ? window.explainerImage : window.currentImage;
+        $('#roundEnd').html('<p>'+window.explainer+'</p><img id="explainerImage" style="max-width:100%;" src="'+explainerImg+'"/><br/><button class="btn btn-primary closeBtn" type="button">Next Round</button>');
     });
 
     // End of game 'play again' button click
@@ -158,7 +165,7 @@ function startGame() {
 
         // If distance is undefined, that means they ran out of time and didn't click the guess button
         if(typeof distance === 'undefined' || ranOut == true){
-            $('#roundEnd').html('<p>Dang nabbit! You took too long!.<br/> You didn\'t score any points this round!<br/><br/><button class="btn btn-primary closeBtn" type="button">Continue</button></p></p>');
+            $('#roundEnd').html('<p>Dang nabbit! You took too long!.<br/> You didn\'t score any points this round!<br/><br/><button class="btn btn-primary continueBtn" type="button">Continue</button></p></p>');
             $('#roundEnd').fadeIn();
             $('#scoreBoard').hide();
 
@@ -179,7 +186,7 @@ function startGame() {
             points = 0;
 
         } else {
-            $('#roundEnd').html('<p>Your guess was<br/><strong><h1>'+distance+'</strong>km</h1> away from the actual location,<br/><h2>'+window.locName+'</h2><div id="roundMap"></div><br/> You have scored<br/><h1>'+roundScore+' points</h1> this round!<br/><br/><button class="btn btn-primary closeBtn" type="button">Continue</button></p></p>');
+            $('#roundEnd').html('<p>Your guess was<br/><strong><h1>'+distance+'</strong>km</h1> away from the actual location,<br/><h2>'+window.locName+'</h2><div id="roundMap"></div><br/> You have scored<br/><h1>'+roundScore+' points</h1> this round!<br/><br/><button class="btn btn-primary continueBtn" type="button">Continue</button></p></p>');
             $('#roundEnd').fadeIn();
             $('#scoreBoard').hide();
         };
@@ -217,8 +224,11 @@ function startGame() {
 
                     var img = document.getElementById('image');
                     img.src = place.image;
+                    window.currentImage = place.image;
                     window.actualLatLng = {lat: place.lat, lon: place.lon};
                     window.locName = place.label;
+                    window.explainer = place.explainer;
+                    window.explainerImage = place.explainerImage;
                 });
             })
             .catch(function(err) {

--- a/locations.json
+++ b/locations.json
@@ -3,37 +3,35 @@
     "image": "https://i.postimg.cc/jq4Nmf8n/temp-Image-Xy-XHc-K.avif",
     "lat": 35.8380,
     "lon": 38.5470,
-    "label": "Tabqa Refugee Camp, Syria"
+    "label": "Tabqa Refugee Camp, Syria",
     "explainer": "Following mass displacement in late 2024, MSF provided clean water, shelter materials, hygiene kits, and ran mobile clinics in Tabqa."
   },
-
   {
-  "image": "https://i.postimg.cc/ydfqNH0z/temp-Image-BPRjum.avif",
-  "lat": 7.7306,
-  "lon": 8.5392,
-  "label": "Makurdi town, near the rice fields. Makurdi, Benue, North Central Nigeria"
-  "explainer": "MSF provides healthcare and support to thousands displaced by farmer-herder violence in Benue state, especially in camps near Makurdi. Services include maternal care, treatment for malaria and malnutrition, and support for survivors of sexual violence. In 2023 alone, MSF treated over 1,700 cases of sexual violence in the area."
-}
- {
-  "image": "https://i.postimg.cc/nrbMsbTc/temp-Image-BNHNya.avif",
-  "lat": 20.8845,
-  "lon": 92.5370,
-  "label": "Burma, Myanmar, MSF staff on their journey to set up a clinic"
-  "explainer": "Amid post-coup instability, MSF continued providing HIV, TB, and basic health services across Myanmar in 2022. Mobile clinics supported displaced people, though access was frequently hampered by conflict and government restrictions."
-}
-{
-  "image": "https://i.postimg.cc/0jVgT76R/temp-Image-AAHa-CH.avif",
-  "lat": 9.2772,
-  "lon": 29.7859,
-  "label": "South-Sudan, Aerial view Bentiu IDP camp"
-  "explainer": "MSF runs the only hospital in Bentiu’s large displacement camp, treating thousands for malaria, respiratory infections, and malnutrition. They also provide maternal care and emergency services, while addressing outbreaks caused by poor sanitation."
-}
+    "image": "https://i.postimg.cc/ydfqNH0z/temp-Image-BPRjum.avif",
+    "lat": 7.7306,
+    "lon": 8.5392,
+    "label": "Makurdi town, near the rice fields. Makurdi, Benue, North Central Nigeria",
+    "explainer": "MSF provides healthcare and support to thousands displaced by farmer-herder violence in Benue state, especially in camps near Makurdi. Services include maternal care, treatment for malaria and malnutrition, and support for survivors of sexual violence. In 2023 alone, MSF treated over 1,700 cases of sexual violence in the area."
+  },
   {
-  "image": "https://i.postimg.cc/YCgng1pr/temp-Image-BRnbx0.avif",
-  "lat": -3.3619,
-  "lon": -64.7199,
-  "label": "Brazil, MSF response to COVID-19 around Tefé"
-  "explainer": "In 2020, MSF helped overwhelmed hospitals in Manaus and sent mobile teams to remote Amazon towns. They provided ICU support, ran isolation centers, and cared for vulnerable communities, including indigenous groups and refugees."
-}
-
+    "image": "https://i.postimg.cc/nrbMsbTc/temp-Image-BNHNya.avif",
+    "lat": 20.8845,
+    "lon": 92.5370,
+    "label": "Burma, Myanmar, MSF staff on their journey to set up a clinic",
+    "explainer": "Amid post-coup instability, MSF continued providing HIV, TB, and basic health services across Myanmar in 2022. Mobile clinics supported displaced people, though access was frequently hampered by conflict and government restrictions."
+  },
+  {
+    "image": "https://i.postimg.cc/0jVgT76R/temp-Image-AAHa-CH.avif",
+    "lat": 9.2772,
+    "lon": 29.7859,
+    "label": "South-Sudan, Aerial view Bentiu IDP camp",
+    "explainer": "MSF runs the only hospital in Bentiu’s large displacement camp, treating thousands for malaria, respiratory infections, and malnutrition. They also provide maternal care and emergency services, while addressing outbreaks caused by poor sanitation."
+  },
+  {
+    "image": "https://i.postimg.cc/YCgng1pr/temp-Image-BRnbx0.avif",
+    "lat": -3.3619,
+    "lon": -64.7199,
+    "label": "Brazil, MSF response to COVID-19 around Tefé",
+    "explainer": "In 2020, MSF helped overwhelmed hospitals in Manaus and sent mobile teams to remote Amazon towns. They provided ICU support, ran isolation centers, and cared for vulnerable communities, including indigenous groups and refugees."
+  }
 ]


### PR DESCRIPTION
## Summary
- add explainer step after each round
- fix `locations.json` formatting and support explainer text

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684fef9e981c83239a50a40fbda04031