### PR TITLE
Enable offline MBTiles map

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Based on [whereami](https://github.com/webdevbrian/whereami), a GeoGuessr reimpl
 
 License: GPLv3+
 ===============
+
+Offline Usage
+-------------
+
+1. Copy `maptiler-osm-2020-02-10-v3.11-planet.mbtiles` into this directory.
+2. Install dependencies with `npm install` (fetches Express, MBTiles, jQuery and Leaflet).
+3. Start the server using `npm run serve`.
+4. Open `http://localhost:3000` in your browser.
+
+On Android devices you can run the Node server via Termux and access the game completely offline.

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
         <title>Wikidata Guessr</title>
         <link rel='stylesheet' href='css/bootstrap.css' />
         <link rel='stylesheet' href='css/style.css' />
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ==" crossorigin=""/>
-        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>
-        <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js" integrity="sha512-A7vV8IFfih/D732iSSKi20u/ooOfj/AGehOKq0f4vLT1Zr2Y+RX7C+w8A1gaSasGtRUZpF/NZgzSAu4/Gc41Lg==" crossorigin=""></script>
+        <link rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css" />
+        <script type='text/javascript' src='node_modules/jquery/dist/jquery.min.js'></script>
+        <script src="node_modules/leaflet/dist/leaflet.js"></script>
         <script type='text/javascript' src='js/rnd.js'></script>
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -7,8 +7,8 @@ function mminitialize() {
 
     mymap.setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    L.tileLayer('/tiles/{z}/{x}/{y}.png', {
+        attribution: 'Offline map',
         maxZoom: 18
     }).addTo(mymap);
 

--- a/js/roundmap.js
+++ b/js/roundmap.js
@@ -5,8 +5,8 @@
 function rminitialize() {
     roundmap = L.map("roundMap").setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    L.tileLayer('/tiles/{z}/{x}/{y}.png', {
+        attribution: 'Offline map',
         maxZoom: 18
     }).addTo(roundmap);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "Custom msf locations guessing game",
   "main": "index.html",
   "scripts": {
-    "start": "live-server --open=./index.html"
+    "start": "live-server --open=./index.html",
+    "serve": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mbtiles": "^0.12.0",
+    "jquery": "^3.7.1",
+    "leaflet": "^1.9.4"
   },
   "devDependencies": {
     "live-server": "^1.2.2"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const path = require('path');
+const MBTiles = require('mbtiles');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// serve static files
+app.use(express.static(path.join(__dirname)));
+
+let mbtiles;
+
+const mbtilesPath = path.join(__dirname, 'maptiler-osm-2020-02-10-v3.11-planet.mbtiles');
+new MBTiles(mbtilesPath, (err, mb) => {
+  if (err) {
+    console.error('Error opening MBTiles file:', err);
+  } else {
+    mbtiles = mb;
+    console.log('MBTiles loaded');
+  }
+});
+
+app.get('/tiles/:z/:x/:y.png', (req, res) => {
+  if (!mbtiles) {
+    res.status(503).send('Tiles not loaded yet');
+    return;
+  }
+  const { z, x, y } = req.params;
+  mbtiles.getTile(z, x, y, (err, data, headers) => {
+    if (err) {
+      res.status(404).send('Tile not found');
+    } else {
+      res.set(headers);
+      res.send(data);
+    }
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node server for serving MBTiles tiles
- update map code to point to `/tiles/...` endpoints
- document how to run the game offline
- add Express and mbtiles dependencies
- serve jQuery and Leaflet locally for offline mode

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685d6a824ff883239957b5b555c0fa9c