### PR TITLE
Add Node.js server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ Based on [whereami](https://github.com/webdevbrian/whereami), a GeoGuessr reimpl
 
 License: GPLv3+
 ===============
+
+Running a local server
+----------------------
+
+If you want to host the game with Node.js, install the dependencies and start
+`server.js`:
+
+```
+npm install
+npm start
+```
+
+The server will expose the project on <http://localhost:8080>. Ensure that your
+MBTiles file (`maptiler-osm-2020-02-10-v3.11-planet.mbtiles`) is placed inside
+the `libs/` directory so that the map tiles can be loaded by the browser.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Custom msf locations guessing game",
   "main": "index.html",
   "scripts": {
-    "start": "live-server --open=./index.html"
+    "start": "node server.js",
+    "live": "live-server --open=./index.html"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "live-server": "^1.2.2"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 8080;
+
+// Serve static files from the project root
+app.use(express.static(path.join(__dirname)));
+
+// Explicitly set content-type for .mbtiles files
+app.get('*.mbtiles', (req, res, next) => {
+  res.type('application/x-sqlite3');
+  next();
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Express server to serve static files
- update package.json with express dependency and script
- document how to run the server in README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68616952cd08832386aa0a9ac3d2adc1