### PR TITLE
Enable offline play with local map tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,13 @@ Guess the locations of random images stored in `locations.json`.
 
 Based on [whereami](https://github.com/webdevbrian/whereami), a GeoGuessr reimplementation by [Brian Kinney](http://www.thebriankinney.com/).
 
+## Offline setup
+
+1. Place your MBTiles file at `tiles/tiles.mbtiles` in the project directory.
+2. Install dependencies with `npm install`.
+3. Start the local server using `npm start` and open the provided URL in your browser.
+
+Any static server such as `python3 -m http.server` will also work, as long as it serves the project root.
+
 License: GPLv3+
 ===============

--- a/index.html
+++ b/index.html
@@ -6,9 +6,17 @@
         <title>Wikidata Guessr</title>
         <link rel='stylesheet' href='css/bootstrap.css' />
         <link rel='stylesheet' href='css/style.css' />
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ==" crossorigin=""/>
-        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>
-        <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js" integrity="sha512-A7vV8IFfih/D732iSSKi20u/ooOfj/AGehOKq0f4vLT1Zr2Y+RX7C+w8A1gaSasGtRUZpF/NZgzSAu4/Gc41Lg==" crossorigin=""></script>
+        <link rel='stylesheet' href='leaflet/leaflet.css' />
+        <script type='text/javascript' src='libs/jquery-3.7.1.min.js'></script>
+        <script src="leaflet/leaflet.js"></script>
+        <script src="libs/sql-wasm.js"></script>
+        <script src="libs/Leaflet.TileLayer.MBTiles.js"></script>
+        <script>
+            // Load sql.js and expose the SQL object globally
+            window.SQLPromise = initSqlJs({ locateFile: file => 'libs/' + file }).then(function(SQL){
+                window.SQL = SQL;
+            });
+        </script>
         <script type='text/javascript' src='js/rnd.js'></script>
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,17 +1,22 @@
-function startGame() {
-    //
-    // Setup
-    //
+var SQLPromise = initSqlJs({ locateFile: file => 'libs/' + file }).then(function(SQL){
+    window.SQL = SQL;
+});
 
-    var round = 1;
-    var points = 0;
-    var roundScore = 0;
-    var totalScore = 0;
-    ranOut = false;
-    var distance;
-    var detailPic = '';
-    var explainerText = '';
-    var locationsPool = [];
+function startGame() {
+    SQLPromise.then(function(){
+        //
+        // Setup
+        //
+
+        var round = 1;
+        var points = 0;
+        var roundScore = 0;
+        var totalScore = 0;
+        ranOut = false;
+        var distance;
+        var detailPic = '';
+        var explainerText = '';
+        var locationsPool = [];
 
     //
     //  Init maps and load locations
@@ -246,6 +251,7 @@ function startGame() {
         }
         return arr;
     }
+    });
 }
 
 $(document).ready(function(){

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -7,10 +7,12 @@ function mminitialize() {
 
     mymap.setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(mymap);
+    window.SQLPromise.then(function(){
+        L.tileLayer.mbTiles('tiles/tiles.mbtiles', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            maxZoom: 18
+        }).addTo(mymap);
+    });
 
     guess2 = L.marker([-999, -999]).addTo(mymap);
     guess2.setLatLng({lat: -999, lng: -999});

--- a/js/roundmap.js
+++ b/js/roundmap.js
@@ -5,10 +5,12 @@
 function rminitialize() {
     roundmap = L.map("roundMap").setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(roundmap);
+    window.SQLPromise.then(function(){
+        L.tileLayer.mbTiles('tiles/tiles.mbtiles', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            maxZoom: 18
+        }).addTo(roundmap);
+    });
 
     var guessIcon = L.icon({
         iconUrl: "img/guess.png",


### PR DESCRIPTION
## Summary
- reference local copies of Leaflet and jQuery
- load sql.js and MBTiles plugin for offline tiles
- fetch tiles from `tiles/tiles.mbtiles`
- initialize SQL before starting the game
- document offline setup steps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861807a2ba883239162c267f37bea5b