### PR TITLE
Update mbtiles dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "@mapbox/mbtiles": "^0.10.0"
+    "@mapbox/mbtiles": "0.10.3"
   },
   "devDependencies": {
     "live-server": "^1.2.2"


### PR DESCRIPTION
## Summary
- bump `@mapbox/mbtiles` to `0.10.3`

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861898f1d6c8323aa14378279c01d2c