### PR TITLE
Improve explainer view UX

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -176,7 +176,8 @@ select {
     display: none;
     z-index: 1005;
     box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
-    overflow: hidden;
+    overflow-y: auto;
+    max-height: 90vh;
 }
 
 #overlay {
@@ -209,10 +210,15 @@ select {
 }
 
 #roundEnd .detailBtn,
-#roundEnd .nextBtn {
+#roundEnd .nextBtn,
+#roundEnd .backBtn {
     padding: 10px 20px;
     font-size: 20px;
     cursor: pointer;
+}
+
+#roundEnd .backBtn {
+    margin-right: 10px;
 }
 
 

--- a/js/app.js
+++ b/js/app.js
@@ -41,6 +41,11 @@ function startGame() {
         $('#roundEnd').addClass('show-details');
     });
 
+    // Return to result view from details
+    $('#roundEnd').on('click', '.backBtn', function () {
+        $('#roundEnd').removeClass('show-details');
+    });
+
     // Proceed to next round
     $('#roundEnd').on('click', '.nextBtn', function () {
         proceedToNextRound();
@@ -148,7 +153,7 @@ function startGame() {
             $('#roundEnd').html(
                 '<div class="slider">'+
                     '<div id="resultContent" class="pane"><p>Dang nabbit! You took too long!.<br/> You didn\'t score any points this round!<br/><br/><button class="btn btn-primary detailBtn" type="button">Continue</button></p></div>'+
-                    '<div id="detailContent" class="pane"><img src="'+detailPic+'" class="detailPic"/><p>'+explainerText+'</p><button class="btn btn-primary nextBtn" type="button">Next Round</button></div>'+
+                    '<div id="detailContent" class="pane"><h2>'+window.locName+'</h2><img src="'+detailPic+'" class="detailPic"/><p>'+explainerText+'</p><button class="btn btn-secondary backBtn" type="button">Retour</button><button class="btn btn-primary nextBtn" type="button">Next Round</button></div>'+
                 '</div>'
             );
             rminitialize();
@@ -184,7 +189,7 @@ function startGame() {
             $('#roundEnd').html(
                 '<div class="slider">'+
                     '<div id="resultContent" class="pane"><p>Your guess was<br/><strong><h1>'+distance+'</strong>km</h1> away from the actual location,<br/><h2>'+window.locName+'</h2><div id="roundMap"></div><br/> You have scored<br/><h1>'+roundScore+' points</h1> this round!<br/><br/><button class="btn btn-primary detailBtn" type="button">Continue</button></p></div>'+
-                    '<div id="detailContent" class="pane"><img src="'+detailPic+'" class="detailPic"/><p>'+explainerText+'</p><button class="btn btn-primary nextBtn" type="button">Next Round</button></div>'+
+                    '<div id="detailContent" class="pane"><h2>'+window.locName+'</h2><img src="'+detailPic+'" class="detailPic"/><p>'+explainerText+'</p><button class="btn btn-secondary backBtn" type="button">Retour</button><button class="btn btn-primary nextBtn" type="button">Next Round</button></div>'+
                 '</div>'
             );
             rminitialize();


### PR DESCRIPTION
## Summary
- make the round end popup scrollable so long text doesn't hide the buttons
- add a Back button for returning to the map
- show the location title again in the explanation pane

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f7d2e75988323957529cd5fa92954