### PR TITLE
Add image container wrapper and adjust zoom logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,100 @@
 html, body {
     width: 100%;
     height: 100%;
-    margin: 0;
-    padding: 0;
     background: white;
-    overflow: hidden;
-    overscroll-behavior: none; /* Prevent swipe navigation/bounce */
+}
+
+#welcomeScreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100dvh;                      /* ensure full viewport height on mobile */
+    background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding-bottom: 40px;              /* keep space below button */
+    box-sizing: border-box;
+    z-index: 2000;
+    animation: fadeIn 1s, gradientPulse 6s ease-in-out infinite;
+}
+
+#welcomeScreen img {
+    max-width: 80%;
+    max-height: calc(100dvh - 200px);  /* keep image from hiding the button */
+}
+
+#welcomeScreen button {
+    margin-top: 20px;
+    margin-bottom: 40px;               /* padding under the button */
+    font-size: 24px;                   /* bigger button text */
+    padding: 12px 32px;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes gradientPulse {
+    0%   { background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%); }
+    50%  { background: radial-gradient(circle, white 20%, rgb(151,231,238) 100%); }
+    100% { background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%); }
+}
+
+button, .btn {
+    background-color: rgb(238, 0, 0);
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+    background-image: none;
+    color: white;
+}
+
+#content {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+#miniMapWrapper {
+    width: 30vw;              /* increased size for large screens */
+    position: absolute;
+    top: 50%;
+    right: 5vw;               /* 5% from right edge */
+    transform: translateY(-50%);
+    z-index: 1000;
+    max-width: 840px;         /* accommodate larger display */
+    min-width: 360px;         /* Still usable on mobile */
+}
+
+#miniMap {
+    width: 100%;
+    height: 35vh;             /* slightly taller on large screens */
+    box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
+    max-height: 600px;
+    min-height: 240px;
+}
+
+#guessButton {
+    font-size: 24px;
+    font-weight: bold;
+    color: white;
+    width: 100%;
+    cursor: pointer;
+    text-align: center;
+    background-color: rgb(238, 0, 0);
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+    background-image: none;
+    padding: 10px 0;
+}
+
+#guessButton:hover {
+    background: rgb(238, 0, 0);
 }
 
 #imageContainer {
@@ -15,33 +104,187 @@ html, body {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    touch-action: none; /* Allow custom pinch/pan */
 }
 
 #image {
     position: absolute;
-    top: 0;
-    left: 0;
-    transform-origin: top left;
-    width: auto;
-    height: auto;
-    max-width: none;
-    max-height: none;
-    cursor: grab;
-    user-select: none;
-    touch-action: none; /* Important: JS handles gestures */
+  top: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  transform-origin: top left;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
 }
 
 #image.grabbing {
     cursor: grabbing;
+    touch-action: none;
 }
 
-/* Mobile adjustments */
+#scoreBoard {
+    position: absolute;
+    bottom: 45px;
+    left: 20px;
+    width: 200px;
+    height: 110px;
+    padding: 10px;
+    background: white;
+    box-shadow: 0px 0px 20px rgba(0,0,0, 0.9);
+    z-index: 1000;
+}
+
 @media (max-width: 767px) {
+    #scoreBoard {
+        position: fixed;
+        top: 0;
+        left: 50%;
+        bottom: auto;
+        right: auto;
+        transform: translateX(-50%);
+        width: auto;
+        height: auto;
+        padding: 5px 10px;
+        display: inline-flex; /* size to content so box remains narrow */
+        flex-wrap: nowrap;
+        gap: 10px;
+        white-space: nowrap;
+        align-items: center;
+    }
+    #scoreBoard .roundScore,
+    #scoreBoard a {
+        display: none;
+    }
+    #scoreBoard br {
+        display: none;
+    }
+}
+
+select {
+    width: 200px;
+}
+
+#scoreBoard .round {
+}
+
+#scoreboard .totalScore {
+}
+
+#roundEnd {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80%;
+    max-width: 800px;
+    margin-top: 40px;
+    padding: 20px 0;
+    background: white;
+    text-align: center;
+    display: none;
+    z-index: 1005;
+    box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
+    overflow-y: auto;
+    max-height: 90vh;
+}
+
+#overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: none;
+    z-index: 1004;
+}
+
+#roundEnd #roundMap {
+    width: 100%;
+    height: 300px;
+    margin: 20px auto;
+}
+
+
+#roundEnd img.detailPic {
+    width: 100%;
+    height: auto;
+    margin-bottom: 20px;
+}
+
+#detailContent p {
+    font-size: 18px;
+    padding: 20px 0;
+}
+
+#roundEnd .detailBtn,
+#roundEnd .nextBtn,
+#roundEnd .backBtn {
+    padding: 10px 20px;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+#roundEnd .backBtn {
+    margin-right: 10px;
+}
+
+
+#roundEnd .slider {
+    display: flex;
+    width: 200%;
+    transition: transform 0.4s ease;
+}
+
+#roundEnd .pane {
+    width: 50%;
+    flex-shrink: 0;
+    padding: 0 20px;
+    box-sizing: border-box;
+}
+
+#roundEnd.show-details .slider {
+    transform: translateX(-50%);
+}
+
+#roundMap {
+    width: 500px;
+    height: 500px;
+    position: relative;
+}
+
+#endGame {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 400px;
+    margin: -190px 0 0 -240px;
+    padding: 20px;
+    background: #EFEFEF;
+    text-align: center;
+    display: none;
+    z-index: 1000;
+}
+
+/* Change cursor when mousing over clickable layer */
+.leaflet-clickable {
+  cursor: default !important;
+}
+
+/* Change cursor when over entire map */
+.leaflet-container {
+    cursor: default !important;
+}
+
+@media (max-width: 767px) {
+    /* show the image only in the top half of the viewport */
     #imageContainer {
         height: 50vh;
     }
 
+    /* place the map at the bottom and make it smaller */
     #miniMapWrapper {
         position: fixed;
         width: 100%;
@@ -51,7 +294,6 @@ html, body {
         top: auto;
         transform: none;
         height: 40vh;
-        z-index: 1000;
     }
 
     #miniMap {
@@ -59,43 +301,25 @@ html, body {
         height: calc(100% - 40px);
     }
 
+    /* smaller guess button on small screens */
     #guessButton {
         font-size: 18px;
         padding: 8px 0;
     }
 
-    #scoreBoard {
-        position: fixed;
-        top: 0;
-        left: 50%;
-        transform: translateX(-50%);
-        width: auto;
-        height: auto;
-        padding: 5px 10px;
-        display: inline-flex;
-        flex-wrap: nowrap;
-        gap: 10px;
-        white-space: nowrap;
-        align-items: center;
-        z-index: 1100;
-    }
-
-    #scoreBoard .roundScore,
-    #scoreBoard a,
-    #scoreBoard br {
-        display: none;
-    }
-
+    /* make the round result and final result boxes fit the viewport */
     #roundEnd,
     #endGame {
         width: 90%;
         left: 50%;
+        right: auto;
         margin: 20px 0 0 0;
         transform: translateX(-50%);
     }
 
     #endGame {
         top: 50%;
+        margin-top: 0;
         transform: translate(-50%, -50%);
     }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,100 +1,11 @@
 html, body {
     width: 100%;
     height: 100%;
+    margin: 0;
+    padding: 0;
     background: white;
-}
-
-#welcomeScreen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100dvh;                      /* ensure full viewport height on mobile */
-    background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding-bottom: 40px;              /* keep space below button */
-    box-sizing: border-box;
-    z-index: 2000;
-    animation: fadeIn 1s, gradientPulse 6s ease-in-out infinite;
-}
-
-#welcomeScreen img {
-    max-width: 80%;
-    max-height: calc(100dvh - 200px);  /* keep image from hiding the button */
-}
-
-#welcomeScreen button {
-    margin-top: 20px;
-    margin-bottom: 40px;               /* padding under the button */
-    font-size: 24px;                   /* bigger button text */
-    padding: 12px 32px;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-@keyframes gradientPulse {
-    0%   { background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%); }
-    50%  { background: radial-gradient(circle, white 20%, rgb(151,231,238) 100%); }
-    100% { background: radial-gradient(circle, white 0%, rgb(151,231,238) 100%); }
-}
-
-button, .btn {
-    background-color: rgb(238, 0, 0);
-    border-radius: 0;
-    border: none;
-    box-shadow: none;
-    background-image: none;
-    color: white;
-}
-
-#content {
-    width: 100%;
-    height: 100%;
-    position: relative;
-}
-
-#miniMapWrapper {
-    width: 30vw;              /* increased size for large screens */
-    position: absolute;
-    top: 50%;
-    right: 5vw;               /* 5% from right edge */
-    transform: translateY(-50%);
-    z-index: 1000;
-    max-width: 840px;         /* accommodate larger display */
-    min-width: 360px;         /* Still usable on mobile */
-}
-
-#miniMap {
-    width: 100%;
-    height: 35vh;             /* slightly taller on large screens */
-    box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
-    max-height: 600px;
-    min-height: 240px;
-}
-
-#guessButton {
-    font-size: 24px;
-    font-weight: bold;
-    color: white;
-    width: 100%;
-    cursor: pointer;
-    text-align: center;
-    background-color: rgb(238, 0, 0);
-    border-radius: 0;
-    border: none;
-    box-shadow: none;
-    background-image: none;
-    padding: 10px 0;
-}
-
-#guessButton:hover {
-    background: rgb(238, 0, 0);
+    overflow: hidden;
+    overscroll-behavior: none; /* Prevent swipe navigation/bounce */
 }
 
 #imageContainer {
@@ -104,187 +15,33 @@ button, .btn {
     width: 100%;
     height: 100%;
     overflow: hidden;
+    touch-action: none; /* Allow custom pinch/pan */
 }
 
 #image {
     position: absolute;
-  top: 0;
-  left: 0;
-  width: auto;
-  height: auto;
-  max-width: none;
-  max-height: none;
-  transform-origin: top left;
-  cursor: grab;
-  user-select: none;
-  touch-action: none;
+    top: 0;
+    left: 0;
+    transform-origin: top left;
+    width: auto;
+    height: auto;
+    max-width: none;
+    max-height: none;
+    cursor: grab;
+    user-select: none;
+    touch-action: none; /* Important: JS handles gestures */
 }
 
 #image.grabbing {
     cursor: grabbing;
-    touch-action: none;
 }
 
-#scoreBoard {
-    position: absolute;
-    bottom: 45px;
-    left: 20px;
-    width: 200px;
-    height: 110px;
-    padding: 10px;
-    background: white;
-    box-shadow: 0px 0px 20px rgba(0,0,0, 0.9);
-    z-index: 1000;
-}
-
+/* Mobile adjustments */
 @media (max-width: 767px) {
-    #scoreBoard {
-        position: fixed;
-        top: 0;
-        left: 50%;
-        bottom: auto;
-        right: auto;
-        transform: translateX(-50%);
-        width: auto;
-        height: auto;
-        padding: 5px 10px;
-        display: inline-flex; /* size to content so box remains narrow */
-        flex-wrap: nowrap;
-        gap: 10px;
-        white-space: nowrap;
-        align-items: center;
-    }
-    #scoreBoard .roundScore,
-    #scoreBoard a {
-        display: none;
-    }
-    #scoreBoard br {
-        display: none;
-    }
-}
-
-select {
-    width: 200px;
-}
-
-#scoreBoard .round {
-}
-
-#scoreboard .totalScore {
-}
-
-#roundEnd {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 80%;
-    max-width: 800px;
-    margin-top: 40px;
-    padding: 20px 0;
-    background: white;
-    text-align: center;
-    display: none;
-    z-index: 1005;
-    box-shadow: 0px 0px 20px rgba(255,255,255, 0.9);
-    overflow-y: auto;
-    max-height: 90vh;
-}
-
-#overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0,0.5);
-    display: none;
-    z-index: 1004;
-}
-
-#roundEnd #roundMap {
-    width: 100%;
-    height: 300px;
-    margin: 20px auto;
-}
-
-
-#roundEnd img.detailPic {
-    width: 100%;
-    height: auto;
-    margin-bottom: 20px;
-}
-
-#detailContent p {
-    font-size: 18px;
-    padding: 20px 0;
-}
-
-#roundEnd .detailBtn,
-#roundEnd .nextBtn,
-#roundEnd .backBtn {
-    padding: 10px 20px;
-    font-size: 20px;
-    cursor: pointer;
-}
-
-#roundEnd .backBtn {
-    margin-right: 10px;
-}
-
-
-#roundEnd .slider {
-    display: flex;
-    width: 200%;
-    transition: transform 0.4s ease;
-}
-
-#roundEnd .pane {
-    width: 50%;
-    flex-shrink: 0;
-    padding: 0 20px;
-    box-sizing: border-box;
-}
-
-#roundEnd.show-details .slider {
-    transform: translateX(-50%);
-}
-
-#roundMap {
-    width: 500px;
-    height: 500px;
-    position: relative;
-}
-
-#endGame {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 400px;
-    margin: -190px 0 0 -240px;
-    padding: 20px;
-    background: #EFEFEF;
-    text-align: center;
-    display: none;
-    z-index: 1000;
-}
-
-/* Change cursor when mousing over clickable layer */
-.leaflet-clickable {
-  cursor: default !important;
-}
-
-/* Change cursor when over entire map */
-.leaflet-container {
-    cursor: default !important;
-}
-
-@media (max-width: 767px) {
-    /* show the image only in the top half of the viewport */
     #imageContainer {
         height: 50vh;
     }
 
-    /* place the map at the bottom and make it smaller */
     #miniMapWrapper {
         position: fixed;
         width: 100%;
@@ -294,6 +51,7 @@ select {
         top: auto;
         transform: none;
         height: 40vh;
+        z-index: 1000;
     }
 
     #miniMap {
@@ -301,25 +59,43 @@ select {
         height: calc(100% - 40px);
     }
 
-    /* smaller guess button on small screens */
     #guessButton {
         font-size: 18px;
         padding: 8px 0;
     }
 
-    /* make the round result and final result boxes fit the viewport */
+    #scoreBoard {
+        position: fixed;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: auto;
+        height: auto;
+        padding: 5px 10px;
+        display: inline-flex;
+        flex-wrap: nowrap;
+        gap: 10px;
+        white-space: nowrap;
+        align-items: center;
+        z-index: 1100;
+    }
+
+    #scoreBoard .roundScore,
+    #scoreBoard a,
+    #scoreBoard br {
+        display: none;
+    }
+
     #roundEnd,
     #endGame {
         width: 90%;
         left: 50%;
-        right: auto;
         margin: 20px 0 0 0;
         transform: translateX(-50%);
     }
 
     #endGame {
         top: 50%;
-        margin-top: 0;
         transform: translate(-50%, -50%);
     }
 

--- a/css/style.css
+++ b/css/style.css
@@ -97,6 +97,15 @@ button, .btn {
     background: rgb(238, 0, 0);
 }
 
+#imageContainer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
 #image {
     position: absolute;
   top: 0;
@@ -271,7 +280,7 @@ select {
 
 @media (max-width: 767px) {
     /* show the image only in the top half of the viewport */
-    #image {
+    #imageContainer {
         height: 50vh;
     }
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,9 @@
                 <div id='miniMap'></div>
                 <div id='guessButton' class="btn btn-large btn-danger">Make Your Guess</div>
             </div>
-            <img id='image' src='' />
+            <div id="imageContainer">
+                <img id='image' src='' />
+            </div>
         </div>
     </body>
 </html>

--- a/js/image_zoom.js
+++ b/js/image_zoom.js
@@ -28,9 +28,19 @@
         ty = Math.min(Math.max(ty, minY), maxY);
     }
 
-    function apply() {
+    function apply(animated = false) {
         clamp();
-        img.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+        if (animated) {
+            img.style.transition = 'transform 0.3s ease';
+            requestAnimationFrame(() => {
+                img.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+            });
+            setTimeout(() => {
+                img.style.transition = ''; // remove transition after animation
+            }, 300);
+        } else {
+            img.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+        }
     }
 
     function onWheel(e) {
@@ -123,5 +133,25 @@
     img.addEventListener('pointercancel', pointerUp);
     document.addEventListener('pointerup', pointerUp);
 
-    apply(); // Initial transform
+    // 🔁 Fit and center the image on load
+    img.addEventListener('load', function () {
+        const containerWidth = container.clientWidth;
+        const containerHeight = container.clientHeight;
+
+        const imageWidth = img.naturalWidth;
+        const imageHeight = img.naturalHeight;
+
+        // Cover logic (like object-fit: cover)
+        const scaleX = containerWidth / imageWidth;
+        const scaleY = containerHeight / imageHeight;
+        scale = Math.max(scaleX, scaleY); // ensure it covers container
+
+        // Center the image
+        const scaledWidth = imageWidth * scale;
+        const scaledHeight = imageHeight * scale;
+        tx = (containerWidth - scaledWidth) / 2;
+        ty = (containerHeight - scaledHeight) / 2;
+
+        apply(true); // with animation
+    });
 })();

--- a/js/image_zoom.js
+++ b/js/image_zoom.js
@@ -4,7 +4,7 @@
     if (!img || !container) return;
 
     let scale = 1;
-    const minScale = 1;
+    let minScale = 1; // will be set on load
     const maxScale = 5;
     let tx = 0;
     let ty = 0;
@@ -36,7 +36,7 @@
                 img.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
             });
             setTimeout(() => {
-                img.style.transition = ''; // remove transition after animation
+                img.style.transition = '';
             }, 300);
         } else {
             img.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
@@ -133,7 +133,6 @@
     img.addEventListener('pointercancel', pointerUp);
     document.addEventListener('pointerup', pointerUp);
 
-    // 🔁 Fit and center the image on load
     img.addEventListener('load', function () {
         const containerWidth = container.clientWidth;
         const containerHeight = container.clientHeight;
@@ -141,17 +140,18 @@
         const imageWidth = img.naturalWidth;
         const imageHeight = img.naturalHeight;
 
-        // Cover logic (like object-fit: cover)
         const scaleX = containerWidth / imageWidth;
         const scaleY = containerHeight / imageHeight;
-        scale = Math.max(scaleX, scaleY); // ensure it covers container
+        scale = Math.max(scaleX, scaleY); // fill container (cover-fit)
 
-        // Center the image
+        minScale = scale; // prevent zooming out below initial size
+
         const scaledWidth = imageWidth * scale;
         const scaledHeight = imageHeight * scale;
+
         tx = (containerWidth - scaledWidth) / 2;
         ty = (containerHeight - scaledHeight) / 2;
 
-        apply(true); // with animation
+        apply(true); // animate on load
     });
 })();

--- a/js/image_zoom.js
+++ b/js/image_zoom.js
@@ -1,6 +1,7 @@
 (function () {
     const img = document.getElementById('image');
-    if (!img) return;
+    const container = document.getElementById('imageContainer');
+    if (!img || !container) return;
 
     let scale = 1;
     const minScale = 1;
@@ -12,7 +13,6 @@
     const start = {};
 
     function clamp() {
-        const container = img.parentElement;
         const containerWidth = container.clientWidth;
         const containerHeight = container.clientHeight;
 


### PR DESCRIPTION
## Summary
- wrap image in `#imageContainer`
- style `#imageContainer` for responsive layout
- clamp image zoom using `#imageContainer`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fc20519948323998cf2d5949c1fc6