### PR TITLE
Enable offline map support

### DIFF
--- a/css/leaflet.css
+++ b/css/leaflet.css
@@ -1,0 +1,1 @@
+/* Placeholder for offline Leaflet CSS; user must supply actual file */

--- a/index.html
+++ b/index.html
@@ -6,9 +6,10 @@
         <title>Wikidata Guessr</title>
         <link rel='stylesheet' href='css/bootstrap.css' />
         <link rel='stylesheet' href='css/style.css' />
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ==" crossorigin=""/>
-        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>
-        <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js" integrity="sha512-A7vV8IFfih/D732iSSKi20u/ooOfj/AGehOKq0f4vLT1Zr2Y+RX7C+w8A1gaSasGtRUZpF/NZgzSAu4/Gc41Lg==" crossorigin=""></script>
+        <link rel="stylesheet" href="css/leaflet.css" />
+        <script type='text/javascript' src='js/jquery.min.js'></script>
+        <script src="js/leaflet.js"></script>
+        <script src="js/protomaps-leaflet.js"></script>
         <script type='text/javascript' src='js/rnd.js'></script>
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>

--- a/js/jquery.min.js
+++ b/js/jquery.min.js
@@ -1,0 +1,1 @@
+/* Placeholder for offline jQuery; user must supply actual file */

--- a/js/leaflet.js
+++ b/js/leaflet.js
@@ -1,0 +1,1 @@
+/* Placeholder for offline Leaflet JS; user must supply actual file */

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -7,10 +7,16 @@ function mminitialize() {
 
     mymap.setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(mymap);
+    if (typeof protomaps !== 'undefined' && protomaps.pmtilesLayer) {
+        protomaps.pmtilesLayer('http://localhost:8080/planet_z8.pmtiles', {
+            maxZoom: 8
+        }).addTo(mymap);
+    } else {
+        L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            maxZoom: 8
+        }).addTo(mymap);
+    }
 
     guess2 = L.marker([-999, -999]).addTo(mymap);
     guess2.setLatLng({lat: -999, lng: -999});

--- a/js/protomaps-leaflet.js
+++ b/js/protomaps-leaflet.js
@@ -1,0 +1,1 @@
+/* Placeholder for protomaps-leaflet JS; user must supply actual library */

--- a/js/roundmap.js
+++ b/js/roundmap.js
@@ -5,10 +5,16 @@
 function rminitialize() {
     roundmap = L.map("roundMap").setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(roundmap);
+    if (typeof protomaps !== 'undefined' && protomaps.pmtilesLayer) {
+        protomaps.pmtilesLayer('http://localhost:8080/planet_z8.pmtiles', {
+            maxZoom: 8
+        }).addTo(roundmap);
+    } else {
+        L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            maxZoom: 8
+        }).addTo(roundmap);
+    }
 
     var guessIcon = L.icon({
         iconUrl: "img/guess.png",


### PR DESCRIPTION
## Summary
- switch index.html to offline JS & CSS assets
- configure minimap for protomaps pmtiles or fallback to OSM
- configure roundmap for protomaps pmtiles or fallback to OSM
- add placeholder libraries for jQuery, Leaflet and protomaps
- placeholder planet_z8.pmtiles asset

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68740d88ff3c8323b5b2964f152bcc64