### PR TITLE
Serve maps offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,10 @@
         <title>Wikidata Guessr</title>
         <link rel='stylesheet' href='css/bootstrap.css' />
         <link rel='stylesheet' href='css/style.css' />
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ==" crossorigin=""/>
-        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>
-        <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js" integrity="sha512-A7vV8IFfih/D732iSSKi20u/ooOfj/AGehOKq0f4vLT1Zr2Y+RX7C+w8A1gaSasGtRUZpF/NZgzSAu4/Gc41Lg==" crossorigin=""></script>
+        <link rel="stylesheet" href="offline_assets/leaflet/leaflet.css" />
+        <script type='text/javascript' src='offline_assets/jquery-3.7.1.min.js'></script>
+        <script src="offline_assets/leaflet/leaflet.js"></script>
+        <script src="offline_assets/protomaps-leaflet.js"></script>
         <script type='text/javascript' src='js/rnd.js'></script>
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -7,10 +7,12 @@ function mminitialize() {
 
     mymap.setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(mymap);
+    const protocol = new pmtiles.Protocol();
+    const layer = new pmtiles.LeafletLayer({
+        url: 'offline_assets/planet_z8.pmtiles',
+        attribution: 'Map data © OpenStreetMap contributors'
+    });
+    layer.addTo(mymap);
 
     guess2 = L.marker([-999, -999]).addTo(mymap);
     guess2.setLatLng({lat: -999, lng: -999});

--- a/js/roundmap.js
+++ b/js/roundmap.js
@@ -5,10 +5,12 @@
 function rminitialize() {
     roundmap = L.map("roundMap").setView([30, 10], 1);
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        maxZoom: 18
-    }).addTo(roundmap);
+    const protocol = new pmtiles.Protocol();
+    const layer = new pmtiles.LeafletLayer({
+        url: 'offline_assets/planet_z8.pmtiles',
+        attribution: 'Map data © OpenStreetMap contributors'
+    });
+    layer.addTo(roundmap);
 
     var guessIcon = L.icon({
         iconUrl: "img/guess.png",


### PR DESCRIPTION
## Summary
- update all HTML references to point to `offline_assets`
- switch map code to load tiles from `planet_z8.pmtiles` via Protomaps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68741908c6dc8323b1a87d96d3174bc0