### PR TITLE
Initialize minimap with PMTiles layer

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -86,7 +86,7 @@ function startGame() {
 
             svinitialize();
             guess2.setLatLng({lat: -999, lng: -999});
-            mymap.setView([30, 10], 1);
+            mymap.setView([0, 0], 2);
 
         } else if (round >= 5){
             endGame();

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -3,14 +3,13 @@
 //
 
 function mminitialize() {
-    mymap = L.map("miniMap");
+    mymap = L.map("miniMap").setView([0, 0], 2);
 
-    mymap.setView([30, 10], 1);
-
-    const pmLayer = new protomaps.PMTilesLayer({
-        url: 'offline_assets/planet_z8.pmtiles'
-    });
-    pmLayer.addTo(mymap);
+    pmtilesLayer({
+        url: 'offline_assets/planet_z8.pmtiles',
+        paint: PAINT_LIGHT,
+        attribution: "\u00a9 OpenStreetMap, \u00a9 Protomaps"
+    }).addTo(mymap);
 
     guess2 = L.marker([-999, -999]).addTo(mymap);
     guess2.setLatLng({lat: -999, lng: -999});


### PR DESCRIPTION
## Summary
- create the minimap with `pmtilesLayer` using built-in `PAINT_LIGHT`
- default map view is `[0,0]` at zoom 2
- reset the minimap view to this default each round

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687423ebed408323b135bc3b2ff2939b