### PR TITLE
Fix capturing guess coordinates

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -62,6 +62,8 @@ function startGame() {
 
             svinitialize();
             guess2.setLatLng({lat: -999, lng: -999});
+            // clear previous guess so player must click again
+            window.guessLatLng = undefined;
             mymap.setView([0, 0], 2);
 
         } else {

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -12,12 +12,16 @@ function mminitialize() {
 
     // Initialize marker
     guess2 = L.marker([0, 0]).addTo(mymap);
-    guess2.setLatLng({ lat: 0, lng: 0 });
+    // no guess selected until the player clicks
+    window.guessLatLng = undefined;
+    guess2.setLatLng([0, 0]);
 
     // Click handler to update marker and global guess
     mymap.on("click", function(e) {
         console.log("Map clicked at", e.latlng); // for debugging
         guess2.setLatLng(e.latlng);
-        
+        // keep the coordinates for when the player submits their guess
+        window.guessLatLng = e.latlng;
+
     });
 }


### PR DESCRIPTION
## Summary
- record the player's guess coordinates when clicking the minimap
- reset `guessLatLng` on new rounds so previous coordinates don't carry over

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687468f4e3d48323a845e46017d5c758